### PR TITLE
Add view session read-only tab with markdown rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,24 @@
 {
   "name": "vscode-claude-sessions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-claude-sessions",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
+      "dependencies": {
+        "@vscode/codicons": "^0.0.36",
+        "markdown-it": "^14.1.1"
+      },
       "devDependencies": {
+        "@types/markdown-it": "^14.1.2",
         "@types/mocha": "^10.0.8",
         "@types/node": "^20.14.10",
         "@types/vscode": "^1.90.0",
         "@typescript-eslint/eslint-plugin": "^8.6.0",
         "@typescript-eslint/parser": "^8.6.0",
-        "@vscode/codicons": "^0.0.36",
         "@vscode/test-electron": "^2.5.0",
         "c8": "^10.1.3",
         "eslint": "^9.10.0",
@@ -375,6 +379,31 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
@@ -622,7 +651,6 @@
       "version": "0.0.36",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
       "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ==",
-      "dev": true,
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/test-electron": {
@@ -732,8 +760,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1110,6 +1137,18 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -1915,6 +1954,15 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.2.7",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
@@ -2114,6 +2162,29 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -2533,6 +2604,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2947,6 +3027,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
         "command": "claudeSessions.toggleSelectionMode",
         "title": "Toggle Selection Mode",
         "icon": "$(checklist)"
+      },
+      {
+        "command": "claudeSessions.viewSession",
+        "title": "View Session",
+        "icon": "$(eye)"
       }
     ],
     "views": {

--- a/package.json
+++ b/package.json
@@ -189,9 +189,11 @@
     ]
   },
   "dependencies": {
-    "@vscode/codicons": "^0.0.36"
+    "@vscode/codicons": "^0.0.36",
+    "markdown-it": "^14.1.1"
   },
   "devDependencies": {
+    "@types/markdown-it": "^14.1.2",
     "@types/mocha": "^10.0.8",
     "@types/node": "^20.14.10",
     "@types/vscode": "^1.90.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import { SessionNode, SessionPromptNode } from "./models";
 import { registerSearchCommands } from "./search/searchCommand";
 import { truncateForTreeLabel } from "./utils/formatting";
 import { confirmAndDeleteSessions, confirmDangerousLaunch } from "./utils/sessionActions";
+import { buildSessionViewHtml } from "./sessionViewHtml";
+import { parseAllUserPrompts } from "./discovery/parsePrompts";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const currentVersion = (
@@ -71,6 +73,33 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     panel.onDidDispose(() => promptPanels.delete(uniqueId));
   };
 
+  // Session view panels (read-only full conversation)
+  const sessionViewPanels = new Map<string, vscode.WebviewPanel>();
+
+  const openSessionView = async (session: SessionNode) => {
+    const existing = sessionViewPanels.get(session.sessionId);
+    if (existing) {
+      existing.reveal(vscode.ViewColumn.Beside);
+      return;
+    }
+
+    const prompts = await parseAllUserPrompts(session.transcriptPath, session.sessionId, (msg) =>
+      outputChannel.appendLine(msg)
+    );
+
+    const tabTitle = truncateForTreeLabel(session.title, 35);
+    const panel = vscode.window.createWebviewPanel(
+      "claudeSessionsView",
+      tabTitle,
+      { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+      { enableScripts: false }
+    );
+
+    panel.webview.html = buildSessionViewHtml(session, prompts);
+    sessionViewPanels.set(session.sessionId, panel);
+    panel.onDidDispose(() => sessionViewPanels.delete(session.sessionId));
+  };
+
   // Create two webview providers sharing the same state
   const explorerProvider = new SessionTreeViewProvider(
     context.extensionUri,
@@ -78,7 +107,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     terminalService,
     discovery,
     outputChannel,
-    openPromptPreview
+    openPromptPreview,
+    openSessionView
   );
 
   const sidebarProvider = new SessionTreeViewProvider(
@@ -87,7 +117,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     terminalService,
     discovery,
     outputChannel,
-    openPromptPreview
+    openPromptPreview,
+    openSessionView
   );
 
   context.subscriptions.push(
@@ -182,6 +213,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         return;
       }
       openPromptPreview(node);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("claudeSessions.viewSession", async (session: SessionNode) => {
+      if (!session || session.kind !== "session") {
+        return;
+      }
+      await openSessionView(session);
     })
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,8 @@ import { registerSearchCommands } from "./search/searchCommand";
 import { truncateForTreeLabel } from "./utils/formatting";
 import { confirmAndDeleteSessions, confirmDangerousLaunch } from "./utils/sessionActions";
 import { buildSessionViewHtml } from "./sessionViewHtml";
-import { parseAllUserPrompts } from "./discovery/parsePrompts";
+import { md, htmlDocument, renderMessageBlock, escapeHtml, formatTimestamp } from "./viewHtml";
+export { escapeHtml } from "./viewHtml";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const currentVersion = (
@@ -75,6 +76,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // Session view panels (read-only full conversation)
   const sessionViewPanels = new Map<string, vscode.WebviewPanel>();
+  const sessionViewInFlight = new Set<string>();
 
   const openSessionView = async (session: SessionNode) => {
     const existing = sessionViewPanels.get(session.sessionId);
@@ -82,22 +84,31 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       existing.reveal(vscode.ViewColumn.Beside);
       return;
     }
+    if (sessionViewInFlight.has(session.sessionId)) {
+      return;
+    }
+    sessionViewInFlight.add(session.sessionId);
 
-    const prompts = await parseAllUserPrompts(session.transcriptPath, session.sessionId, (msg) =>
-      outputChannel.appendLine(msg)
-    );
+    try {
+      const prompts = await discovery.getUserPrompts(session);
 
-    const tabTitle = truncateForTreeLabel(session.title, 35);
-    const panel = vscode.window.createWebviewPanel(
-      "claudeSessionsView",
-      tabTitle,
-      { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
-      { enableScripts: false }
-    );
+      const tabTitle = truncateForTreeLabel(session.title, 35);
+      const panel = vscode.window.createWebviewPanel(
+        "claudeSessionsView",
+        tabTitle,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+        { enableScripts: false }
+      );
 
-    panel.webview.html = buildSessionViewHtml(session, prompts);
-    sessionViewPanels.set(session.sessionId, panel);
-    panel.onDidDispose(() => sessionViewPanels.delete(session.sessionId));
+      panel.webview.html = buildSessionViewHtml(session, prompts);
+      sessionViewPanels.set(session.sessionId, panel);
+      panel.onDidDispose(() => sessionViewPanels.delete(session.sessionId));
+    } catch (err) {
+      outputChannel.appendLine(`[viewSession] Failed to open session ${session.sessionId}: ${String(err)}`);
+      void vscode.window.showErrorMessage(`Failed to open session: ${String(err)}`);
+    } finally {
+      sessionViewInFlight.delete(session.sessionId);
+    }
   };
 
   // Create two webview providers sharing the same state
@@ -271,33 +282,44 @@ export function deactivate(): void {
   // no-op
 }
 
-export function escapeHtml(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
-
 export function buildPromptPreviewHtml(node: SessionPromptNode): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<style>
-  body { font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-editor-foreground); background: var(--vscode-editor-background); padding: 16px; line-height: 1.5; }
-  h1 { font-size: 1.4em; margin-bottom: 0.5em; }
-  h2 { font-size: 1.1em; margin-top: 1.5em; }
-  ul { padding-left: 1.5em; }
-  code { background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15)); padding: 2px 4px; border-radius: 3px; }
-  pre { background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15)); padding: 12px; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; }
-</style>
-</head>
-<body>
-  <h1>${escapeHtml(node.sessionTitle)}</h1>
-  <ul>
-    <li>Session ID: <code>${escapeHtml(node.sessionId)}</code></li>
-    <li>Prompt #: ${String(node.promptIndex + 1)}</li>
-    <li>Timestamp: ${escapeHtml(node.timestampIso ?? "unavailable")}</li>
-  </ul>
-  <h2>User Prompt</h2>
-  <pre>${escapeHtml(node.promptRaw)}</pre>
-</body>
-</html>`;
+  const ts = formatTimestamp(node.timestampMs, node.timestampIso) || "unavailable";
+
+  const responseBlock = node.responseRaw ? renderMessageBlock("assistant", md.render(node.responseRaw)) : "";
+
+  const extraStyles = `
+  .prompt-header {
+    border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
+    padding-bottom: 12px;
+    margin-bottom: 20px;
+  }
+  .prompt-header h1 { font-size: 1.3em; margin: 0 0 6px 0; }
+  .prompt-meta {
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground);
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .prompt-meta code {
+    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 0.95em;
+  }`;
+
+  const body = `
+  <div class="prompt-header">
+    <h1>${escapeHtml(node.sessionTitle)}</h1>
+    <div class="prompt-meta">
+      <span>Session: <code>${escapeHtml(node.sessionId)}</code></span>
+      <span>Prompt #${String(node.promptIndex + 1)}</span>
+      <span>${escapeHtml(ts)}</span>
+    </div>
+  </div>
+  ${renderMessageBlock("user", md.render(node.promptRaw))}
+  ${responseBlock}`;
+
+  return htmlDocument(extraStyles, body);
 }

--- a/src/sessionViewHtml.ts
+++ b/src/sessionViewHtml.ts
@@ -1,0 +1,130 @@
+import { SessionNode } from "./models";
+import { SessionPrompt } from "./discovery/types";
+import { escapeHtml } from "./extension";
+
+export function buildSessionViewHtml(session: SessionNode, prompts: SessionPrompt[]): string {
+  const formattedDate = new Date(session.updatedAt).toLocaleString();
+
+  const conversationHtml = prompts
+    .map((prompt) => {
+      const ts = prompt.timestampIso ? new Date(prompt.timestampIso).toLocaleString() : "";
+      const userBlock = `<div class="message user-message">
+      <div class="message-header"><span class="role-label user-role">User</span><span class="timestamp">${escapeHtml(ts)}</span></div>
+      <pre class="message-body">${escapeHtml(prompt.promptRaw)}</pre>
+    </div>`;
+
+      const assistantBlock = prompt.responseRaw
+        ? `<div class="message assistant-message">
+          <div class="message-header"><span class="role-label assistant-role">Assistant</span></div>
+          <pre class="message-body">${escapeHtml(prompt.responseRaw)}</pre>
+        </div>`
+        : "";
+
+      return userBlock + assistantBlock;
+    })
+    .join("\n");
+
+  const emptyMsg = prompts.length === 0 ? '<div class="empty-state">No prompts found in this session.</div>' : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+<style>
+  body {
+    font-family: var(--vscode-font-family, sans-serif);
+    color: var(--vscode-editor-foreground);
+    background: var(--vscode-editor-background);
+    padding: 16px 24px;
+    line-height: 1.6;
+    margin: 0;
+  }
+  .session-header {
+    border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
+    padding-bottom: 12px;
+    margin-bottom: 20px;
+  }
+  .session-header h1 {
+    font-size: 1.3em;
+    margin: 0 0 6px 0;
+  }
+  .session-meta {
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground);
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .session-meta code {
+    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 0.95em;
+  }
+  .message {
+    margin-bottom: 20px;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
+  }
+  .message-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 12px;
+    font-size: 0.85em;
+    background: var(--vscode-sideBarSectionHeader-background, rgba(128,128,128,0.1));
+  }
+  .role-label {
+    font-weight: 600;
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+  .user-role {
+    background: var(--vscode-badge-background, rgba(0,122,204,0.2));
+    color: var(--vscode-badge-foreground, var(--vscode-editor-foreground));
+  }
+  .assistant-role {
+    background: var(--vscode-testing-iconPassed, rgba(40,167,69,0.2));
+    color: var(--vscode-editor-foreground);
+  }
+  .timestamp {
+    color: var(--vscode-descriptionForeground);
+  }
+  .message-body {
+    margin: 0;
+    padding: 12px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 0.9em;
+    background: transparent;
+    overflow-x: auto;
+  }
+  .empty-state {
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+    padding: 20px 0;
+  }
+</style>
+</head>
+<body>
+  <div class="session-header">
+    <h1>${escapeHtml(session.title)}</h1>
+    <div class="session-meta">
+      <span>ID: <code>${escapeHtml(session.sessionId)}</code></span>
+      <span>Updated: ${escapeHtml(formattedDate)}</span>
+      <span>Prompts: ${String(prompts.length)}</span>
+      <span>Directory: <code>${escapeHtml(session.cwd)}</code></span>
+    </div>
+  </div>
+  ${emptyMsg}
+  ${conversationHtml}
+</body>
+</html>`;
+}

--- a/src/sessionViewHtml.ts
+++ b/src/sessionViewHtml.ts
@@ -1,6 +1,9 @@
+import MarkdownIt from "markdown-it";
 import { SessionNode } from "./models";
 import { SessionPrompt } from "./discovery/types";
 import { escapeHtml } from "./extension";
+
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
 
 export function buildSessionViewHtml(session: SessionNode, prompts: SessionPrompt[]): string {
   const formattedDate = new Date(session.updatedAt).toLocaleString();
@@ -10,13 +13,13 @@ export function buildSessionViewHtml(session: SessionNode, prompts: SessionPromp
       const ts = prompt.timestampIso ? new Date(prompt.timestampIso).toLocaleString() : "";
       const userBlock = `<div class="message user-message">
       <div class="message-header"><span class="role-label user-role">User</span><span class="timestamp">${escapeHtml(ts)}</span></div>
-      <pre class="message-body">${escapeHtml(prompt.promptRaw)}</pre>
+      <div class="message-body markdown-body">${md.render(prompt.promptRaw)}</div>
     </div>`;
 
       const assistantBlock = prompt.responseRaw
         ? `<div class="message assistant-message">
           <div class="message-header"><span class="role-label assistant-role">Assistant</span></div>
-          <pre class="message-body">${escapeHtml(prompt.responseRaw)}</pre>
+          <div class="message-body markdown-body">${md.render(prompt.responseRaw)}</div>
         </div>`
         : "";
 
@@ -97,19 +100,95 @@ export function buildSessionViewHtml(session: SessionNode, prompts: SessionPromp
     color: var(--vscode-descriptionForeground);
   }
   .message-body {
-    margin: 0;
-    padding: 12px;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-family: var(--vscode-editor-font-family, monospace);
-    font-size: 0.9em;
+    padding: 12px 16px;
     background: transparent;
-    overflow-x: auto;
   }
   .empty-state {
     color: var(--vscode-descriptionForeground);
     font-style: italic;
     padding: 20px 0;
+  }
+
+  /* Markdown styles */
+  .markdown-body {
+    font-size: 0.95em;
+    line-height: 1.65;
+  }
+  .markdown-body > *:first-child { margin-top: 0; }
+  .markdown-body > *:last-child { margin-bottom: 0; }
+  .markdown-body h1,
+  .markdown-body h2,
+  .markdown-body h3,
+  .markdown-body h4,
+  .markdown-body h5,
+  .markdown-body h6 {
+    margin: 1em 0 0.4em;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+  .markdown-body h1 { font-size: 1.4em; }
+  .markdown-body h2 { font-size: 1.2em; }
+  .markdown-body h3 { font-size: 1.05em; }
+  .markdown-body p { margin: 0.5em 0; }
+  .markdown-body ul,
+  .markdown-body ol {
+    margin: 0.4em 0;
+    padding-left: 1.6em;
+  }
+  .markdown-body li { margin: 0.2em 0; }
+  .markdown-body code {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 0.9em;
+    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .markdown-body pre {
+    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.12));
+    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
+    border-radius: 4px;
+    padding: 10px 14px;
+    overflow-x: auto;
+    margin: 0.6em 0;
+  }
+  .markdown-body pre code {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    font-size: 0.9em;
+    white-space: pre;
+  }
+  .markdown-body blockquote {
+    margin: 0.5em 0;
+    padding: 4px 12px;
+    border-left: 3px solid var(--vscode-textBlockQuote-border, rgba(128,128,128,0.4));
+    background: var(--vscode-textBlockQuote-background, rgba(128,128,128,0.05));
+    color: var(--vscode-descriptionForeground);
+  }
+  .markdown-body table {
+    border-collapse: collapse;
+    margin: 0.6em 0;
+    font-size: 0.9em;
+    width: 100%;
+  }
+  .markdown-body th,
+  .markdown-body td {
+    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
+    padding: 5px 10px;
+    text-align: left;
+  }
+  .markdown-body th {
+    background: var(--vscode-sideBarSectionHeader-background, rgba(128,128,128,0.1));
+    font-weight: 600;
+  }
+  .markdown-body a {
+    color: var(--vscode-textLink-foreground);
+    text-decoration: none;
+  }
+  .markdown-body hr {
+    border: none;
+    border-top: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
+    margin: 1em 0;
   }
 </style>
 </head>

--- a/src/sessionViewHtml.ts
+++ b/src/sessionViewHtml.ts
@@ -1,57 +1,32 @@
-import MarkdownIt from "markdown-it";
 import { SessionNode } from "./models";
 import { SessionPrompt } from "./discovery/types";
-import { escapeHtml } from "./extension";
-
-const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+import { md, htmlDocument, renderMessageBlock, escapeHtml, formatTimestamp } from "./viewHtml";
 
 export function buildSessionViewHtml(session: SessionNode, prompts: SessionPrompt[]): string {
   const formattedDate = new Date(session.updatedAt).toLocaleString();
 
   const conversationHtml = prompts
     .map((prompt) => {
-      const ts = prompt.timestampIso ? new Date(prompt.timestampIso).toLocaleString() : "";
-      const userBlock = `<div class="message user-message">
-      <div class="message-header"><span class="role-label user-role">User</span><span class="timestamp">${escapeHtml(ts)}</span></div>
-      <div class="message-body markdown-body">${md.render(prompt.promptRaw)}</div>
-    </div>`;
-
-      const assistantBlock = prompt.responseRaw
-        ? `<div class="message assistant-message">
-          <div class="message-header"><span class="role-label assistant-role">Assistant</span></div>
-          <div class="message-body markdown-body">${md.render(prompt.responseRaw)}</div>
-        </div>`
-        : "";
-
+      const ts = formatTimestamp(prompt.timestampMs, prompt.timestampIso);
+      const userBlock = renderMessageBlock(
+        "user",
+        md.render(prompt.promptRaw),
+        `<span class="timestamp">${escapeHtml(ts)}</span>`
+      );
+      const assistantBlock = prompt.responseRaw ? renderMessageBlock("assistant", md.render(prompt.responseRaw)) : "";
       return userBlock + assistantBlock;
     })
     .join("\n");
 
   const emptyMsg = prompts.length === 0 ? '<div class="empty-state">No prompts found in this session.</div>' : "";
 
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
-<style>
-  body {
-    font-family: var(--vscode-font-family, sans-serif);
-    color: var(--vscode-editor-foreground);
-    background: var(--vscode-editor-background);
-    padding: 16px 24px;
-    line-height: 1.6;
-    margin: 0;
-  }
+  const extraStyles = `
   .session-header {
     border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
     padding-bottom: 12px;
     margin-bottom: 20px;
   }
-  .session-header h1 {
-    font-size: 1.3em;
-    margin: 0 0 6px 0;
-  }
+  .session-header h1 { font-size: 1.3em; margin: 0 0 6px 0; }
   .session-meta {
     font-size: 0.85em;
     color: var(--vscode-descriptionForeground);
@@ -66,133 +41,13 @@ export function buildSessionViewHtml(session: SessionNode, prompts: SessionPromp
     font-family: var(--vscode-editor-font-family, monospace);
     font-size: 0.95em;
   }
-  .message {
-    margin-bottom: 20px;
-    border-radius: 4px;
-    overflow: hidden;
-    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
-  }
-  .message-header {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 6px 12px;
-    font-size: 0.85em;
-    background: var(--vscode-sideBarSectionHeader-background, rgba(128,128,128,0.1));
-  }
-  .role-label {
-    font-weight: 600;
-    font-size: 0.8em;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 2px 6px;
-    border-radius: 3px;
-  }
-  .user-role {
-    background: var(--vscode-badge-background, rgba(0,122,204,0.2));
-    color: var(--vscode-badge-foreground, var(--vscode-editor-foreground));
-  }
-  .assistant-role {
-    background: var(--vscode-testing-iconPassed, rgba(40,167,69,0.2));
-    color: var(--vscode-editor-foreground);
-  }
-  .timestamp {
-    color: var(--vscode-descriptionForeground);
-  }
-  .message-body {
-    padding: 12px 16px;
-    background: transparent;
-  }
   .empty-state {
     color: var(--vscode-descriptionForeground);
     font-style: italic;
     padding: 20px 0;
-  }
+  }`;
 
-  /* Markdown styles */
-  .markdown-body {
-    font-size: 0.95em;
-    line-height: 1.65;
-  }
-  .markdown-body > *:first-child { margin-top: 0; }
-  .markdown-body > *:last-child { margin-bottom: 0; }
-  .markdown-body h1,
-  .markdown-body h2,
-  .markdown-body h3,
-  .markdown-body h4,
-  .markdown-body h5,
-  .markdown-body h6 {
-    margin: 1em 0 0.4em;
-    font-weight: 600;
-    line-height: 1.3;
-  }
-  .markdown-body h1 { font-size: 1.4em; }
-  .markdown-body h2 { font-size: 1.2em; }
-  .markdown-body h3 { font-size: 1.05em; }
-  .markdown-body p { margin: 0.5em 0; }
-  .markdown-body ul,
-  .markdown-body ol {
-    margin: 0.4em 0;
-    padding-left: 1.6em;
-  }
-  .markdown-body li { margin: 0.2em 0; }
-  .markdown-body code {
-    font-family: var(--vscode-editor-font-family, monospace);
-    font-size: 0.9em;
-    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
-    padding: 1px 5px;
-    border-radius: 3px;
-  }
-  .markdown-body pre {
-    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.12));
-    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
-    border-radius: 4px;
-    padding: 10px 14px;
-    overflow-x: auto;
-    margin: 0.6em 0;
-  }
-  .markdown-body pre code {
-    background: transparent;
-    padding: 0;
-    border-radius: 0;
-    font-size: 0.9em;
-    white-space: pre;
-  }
-  .markdown-body blockquote {
-    margin: 0.5em 0;
-    padding: 4px 12px;
-    border-left: 3px solid var(--vscode-textBlockQuote-border, rgba(128,128,128,0.4));
-    background: var(--vscode-textBlockQuote-background, rgba(128,128,128,0.05));
-    color: var(--vscode-descriptionForeground);
-  }
-  .markdown-body table {
-    border-collapse: collapse;
-    margin: 0.6em 0;
-    font-size: 0.9em;
-    width: 100%;
-  }
-  .markdown-body th,
-  .markdown-body td {
-    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
-    padding: 5px 10px;
-    text-align: left;
-  }
-  .markdown-body th {
-    background: var(--vscode-sideBarSectionHeader-background, rgba(128,128,128,0.1));
-    font-weight: 600;
-  }
-  .markdown-body a {
-    color: var(--vscode-textLink-foreground);
-    text-decoration: none;
-  }
-  .markdown-body hr {
-    border: none;
-    border-top: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
-    margin: 1em 0;
-  }
-</style>
-</head>
-<body>
+  const body = `
   <div class="session-header">
     <h1>${escapeHtml(session.title)}</h1>
     <div class="session-meta">
@@ -203,7 +58,7 @@ export function buildSessionViewHtml(session: SessionNode, prompts: SessionPromp
     </div>
   </div>
   ${emptyMsg}
-  ${conversationHtml}
-</body>
-</html>`;
+  ${conversationHtml}`;
+
+  return htmlDocument(extraStyles, body);
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -51,9 +51,10 @@ describe("buildPromptPreviewHtml", () => {
     assert.ok(result.includes("<!DOCTYPE html>"), "should be a full HTML document");
     assert.ok(result.includes("<h1>My Session</h1>"), "should include session title as H1");
     assert.ok(result.includes("sess-001"), "should include session ID");
-    assert.ok(result.includes("Prompt #: 1"), "should show 1-based prompt number");
-    assert.ok(result.includes("2024-01-15T10:30:00.000Z"), "should include timestamp");
-    assert.ok(result.includes("Hello, world!"), "should include prompt text in <pre> block");
+    assert.ok(result.includes("Prompt #1"), "should show 1-based prompt number");
+    const expectedTs = new Date("2024-01-15T10:30:00.000Z").toLocaleString();
+    assert.ok(result.includes(expectedTs), "should include formatted timestamp");
+    assert.ok(result.includes("Hello, world!"), "should include prompt text in rendered output");
   });
 
   it("shows 'unavailable' when timestampIso is missing", () => {
@@ -61,21 +62,63 @@ describe("buildPromptPreviewHtml", () => {
     const result = buildPromptPreviewHtml(node);
 
     assert.ok(result.includes("unavailable"), "should show unavailable when timestampIso is missing");
-    assert.ok(result.includes("Prompt #: 3"), "should show correct 1-based prompt index");
+    assert.ok(result.includes("Prompt #3"), "should show correct 1-based prompt index");
   });
 
-  it("escapes HTML special characters in session title and prompt", () => {
+  it("escapes HTML special characters in session title", () => {
     const node: SessionPromptNode = {
       ...baseNode,
-      sessionTitle: 'Session <script>alert("xss")</script>',
-      promptRaw: "User input with <tags> & special chars"
+      sessionTitle: 'Session <script>alert("xss")</script>'
     };
     const result = buildPromptPreviewHtml(node);
 
-    assert.ok(!result.includes("<script>"), "should not contain raw script tags");
+    assert.ok(!result.includes("<script>"), "should not contain raw script tags in title");
     assert.ok(result.includes("&lt;script&gt;"), "should escape script tags in title");
-    assert.ok(result.includes("&lt;tags&gt;"), "should escape tags in prompt");
-    assert.ok(result.includes("&amp; special"), "should escape ampersands in prompt");
+  });
+
+  it("renders markdown bold in prompt as <strong>", () => {
+    const node: SessionPromptNode = { ...baseNode, promptRaw: "This is **bold** text" };
+    const result = buildPromptPreviewHtml(node);
+
+    assert.ok(result.includes("<strong>bold</strong>"), "should render **bold** as <strong>bold</strong>");
+  });
+
+  it("renders responseRaw when provided and shows assistant block", () => {
+    const node: SessionPromptNode = { ...baseNode, responseRaw: "Here is the answer." };
+    const result = buildPromptPreviewHtml(node);
+
+    assert.ok(result.includes("Here is the answer."), "should include response text in output");
+    assert.ok(result.includes("assistant-message"), "should include assistant message block");
+  });
+
+  it("does not include assistant block when responseRaw is absent", () => {
+    const node: SessionPromptNode = { ...baseNode, responseRaw: undefined };
+    const result = buildPromptPreviewHtml(node);
+
+    assert.ok(!result.includes("assistant-message"), "should not include assistant message block");
+  });
+
+  it("contains role-label and user-role CSS classes", () => {
+    const result = buildPromptPreviewHtml(baseNode);
+
+    assert.ok(result.includes("role-label"), "should include role-label CSS class");
+    assert.ok(result.includes("user-role"), "should include user-role CSS class");
+  });
+
+  it("contains Content-Security-Policy meta tag", () => {
+    const result = buildPromptPreviewHtml(baseNode);
+
+    assert.ok(result.includes("Content-Security-Policy"), "should include CSP meta tag");
+  });
+
+  it("escapes XSS script tag in prompt via markdown rendering", () => {
+    const node: SessionPromptNode = {
+      ...baseNode,
+      promptRaw: "User input with <script>alert(1)</script>"
+    };
+    const result = buildPromptPreviewHtml(node);
+
+    assert.ok(!result.includes("<script>alert(1)</script>"), "should not contain raw script tag in prompt");
   });
 });
 
@@ -123,6 +166,14 @@ describe("command guard smoke tests", () => {
   it("claudeSessions.clearFilter does not throw an unhandled error", async () => {
     try {
       await vscode.commands.executeCommand("claudeSessions.clearFilter");
+    } catch {
+      // Commands may throw or show error messages; neither is an unhandled crash
+    }
+  });
+
+  it("claudeSessions.viewSession with undefined payload does not throw an unhandled error", async () => {
+    try {
+      await vscode.commands.executeCommand("claudeSessions.viewSession", undefined);
     } catch {
       // Commands may throw or show error messages; neither is an unhandled crash
     }

--- a/src/test/suite/sessionViewHtml.test.ts
+++ b/src/test/suite/sessionViewHtml.test.ts
@@ -1,0 +1,141 @@
+import * as assert from "assert";
+import { buildSessionViewHtml } from "../../sessionViewHtml";
+import { SessionNode } from "../../models";
+import { SessionPrompt } from "../../discovery/types";
+
+function makeSession(overrides: Partial<SessionNode> = {}): SessionNode {
+  return {
+    kind: "session",
+    sessionId: "test-session-id",
+    title: "Test Session",
+    cwd: "/home/user/project",
+    transcriptPath: "/home/user/.claude/projects/proj/test.jsonl",
+    updatedAt: new Date("2024-01-15T10:00:00Z").getTime(),
+    ...overrides
+  };
+}
+
+function makePrompt(overrides: Partial<SessionPrompt> = {}): SessionPrompt {
+  return {
+    promptId: "prompt-1",
+    sessionId: "test-session-id",
+    promptRaw: "Hello world",
+    promptTitle: "Hello world",
+    timestampIso: "2024-01-15T10:00:00Z",
+    timestampMs: new Date("2024-01-15T10:00:00Z").getTime(),
+    ...overrides
+  };
+}
+
+describe("buildSessionViewHtml", () => {
+  it("shows 'No prompts found in this session.' when prompts array is empty", () => {
+    const html = buildSessionViewHtml(makeSession(), []);
+    assert.ok(html.includes("No prompts found in this session."), "should show empty state message");
+  });
+
+  it("contains session title in the header", () => {
+    const html = buildSessionViewHtml(makeSession({ title: "My Project Session" }), []);
+    assert.ok(html.includes("My Project Session"), "should include session title");
+  });
+
+  it("contains session ID in the header", () => {
+    const html = buildSessionViewHtml(makeSession(), []);
+    assert.ok(html.includes("test-session-id"), "should include session ID");
+  });
+
+  it("contains cwd in the header", () => {
+    const html = buildSessionViewHtml(makeSession(), []);
+    assert.ok(html.includes("/home/user/project"), "should include working directory");
+  });
+
+  it("shows correct prompt count for 3 prompts", () => {
+    const prompts = [makePrompt(), makePrompt({ promptId: "p2" }), makePrompt({ promptId: "p3" })];
+    const html = buildSessionViewHtml(makeSession(), prompts);
+    assert.ok(html.includes("Prompts: 3"), "should display correct prompt count");
+  });
+
+  it("includes user prompt text in output", () => {
+    const html = buildSessionViewHtml(makeSession(), [makePrompt({ promptRaw: "What is TypeScript?" })]);
+    assert.ok(html.includes("What is TypeScript?"), "should include user prompt text");
+  });
+
+  it("renders markdown bold as <strong>", () => {
+    const html = buildSessionViewHtml(makeSession(), [makePrompt({ promptRaw: "This is **bold** text" })]);
+    assert.ok(html.includes("<strong>bold</strong>"), "should render **bold** as <strong>bold</strong>");
+  });
+
+  it("renders fenced code block as <pre><code>", () => {
+    const prompt = makePrompt({ promptRaw: "Example:\n```\nconst x = 1;\n```" });
+    const html = buildSessionViewHtml(makeSession(), [prompt]);
+    assert.ok(html.includes("<pre>"), "should render fenced code block with <pre>");
+    assert.ok(html.includes("<code>"), "should render fenced code block with <code>");
+  });
+
+  it("includes assistant response content when responseRaw is set", () => {
+    const prompt = makePrompt({ responseRaw: "TypeScript is a typed superset of JavaScript." });
+    const html = buildSessionViewHtml(makeSession(), [prompt]);
+    assert.ok(html.includes("TypeScript is a typed superset of JavaScript."), "should include assistant response text");
+  });
+
+  it("does not include assistant-role label when responseRaw is undefined", () => {
+    const prompt = makePrompt({ responseRaw: undefined });
+    const html = buildSessionViewHtml(makeSession(), [prompt]);
+    assert.ok(!html.includes("assistant-message"), "should not include assistant message block when no response");
+  });
+
+  it("includes all prompt texts when multiple prompts are given", () => {
+    const prompts = [
+      makePrompt({ promptId: "p1", promptRaw: "First question" }),
+      makePrompt({ promptId: "p2", promptRaw: "Second question" }),
+      makePrompt({ promptId: "p3", promptRaw: "Third question" })
+    ];
+    const html = buildSessionViewHtml(makeSession(), prompts);
+    assert.ok(html.includes("First question"), "should include first prompt");
+    assert.ok(html.includes("Second question"), "should include second prompt");
+    assert.ok(html.includes("Third question"), "should include third prompt");
+  });
+
+  it("escapes <script> tag in prompt — no raw script tag in output", () => {
+    const prompt = makePrompt({ promptRaw: "<script>alert(1)</script>" });
+    const html = buildSessionViewHtml(makeSession(), [prompt]);
+    assert.ok(!html.includes("<script>alert(1)</script>"), "should not contain raw script tag in prompt body");
+  });
+
+  it("contains Content-Security-Policy meta tag", () => {
+    const html = buildSessionViewHtml(makeSession(), []);
+    assert.ok(html.includes("Content-Security-Policy"), "should include CSP meta tag");
+  });
+
+  it("contains role-label and user-role CSS classes when there are prompts", () => {
+    const html = buildSessionViewHtml(makeSession(), [makePrompt()]);
+    assert.ok(html.includes("role-label"), "should include role-label CSS class");
+    assert.ok(html.includes("user-role"), "should include user-role CSS class");
+  });
+
+  it("contains assistant-role CSS class when responseRaw is present", () => {
+    const prompt = makePrompt({ responseRaw: "Some response." });
+    const html = buildSessionViewHtml(makeSession(), [prompt]);
+    assert.ok(html.includes("assistant-message"), "should include assistant message block");
+  });
+
+  it("includes a formatted date string when timestampIso is present", () => {
+    const prompt = makePrompt({ timestampIso: "2024-01-15T10:00:00Z" });
+    const html = buildSessionViewHtml(makeSession(), [prompt]);
+    const expectedTs = new Date("2024-01-15T10:00:00Z").toLocaleString();
+    assert.ok(html.includes(expectedTs), "should include the locale-formatted timestamp");
+  });
+
+  it("does not crash and produces valid HTML when timestampIso is undefined", () => {
+    const prompt = makePrompt({ timestampIso: undefined, timestampMs: undefined });
+    const html = buildSessionViewHtml(makeSession(), [prompt]);
+    assert.ok(html.includes("<!DOCTYPE html>"), "should still produce valid HTML without timestamp");
+    assert.ok(html.includes("Hello world"), "should still include prompt text");
+  });
+
+  it("HTML-escapes special characters in session title", () => {
+    const session = makeSession({ title: 'Session <script>alert("xss")</script>' });
+    const html = buildSessionViewHtml(session, []);
+    assert.ok(!html.includes("<script>"), "should not include raw script tag in title");
+    assert.ok(html.includes("&lt;script&gt;"), "should HTML-escape script tag in session title");
+  });
+});

--- a/src/viewHtml.ts
+++ b/src/viewHtml.ts
@@ -1,0 +1,152 @@
+import MarkdownIt from "markdown-it";
+
+export const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+md.disable(["image"]);
+
+export function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+export function formatTimestamp(timestampMs: number | undefined, timestampIso: string | undefined): string {
+  if (timestampMs !== undefined) {
+    return new Date(timestampMs).toLocaleString();
+  }
+  if (timestampIso !== undefined) {
+    const parsed = Date.parse(timestampIso);
+    if (Number.isFinite(parsed)) {
+      return new Date(parsed).toLocaleString();
+    }
+  }
+  return "";
+}
+
+export const sharedStyles = `
+  body {
+    font-family: var(--vscode-font-family, sans-serif);
+    color: var(--vscode-editor-foreground);
+    background: var(--vscode-editor-background);
+    padding: 16px 24px;
+    line-height: 1.6;
+    margin: 0;
+  }
+  .message {
+    margin-bottom: 20px;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
+  }
+  .message-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 12px;
+    font-size: 0.85em;
+    background: var(--vscode-sideBarSectionHeader-background, rgba(128,128,128,0.1));
+  }
+  .role-label {
+    font-weight: 600;
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+  .user-role {
+    background: var(--vscode-badge-background, rgba(0,122,204,0.2));
+    color: var(--vscode-badge-foreground, var(--vscode-editor-foreground));
+  }
+  .assistant-role {
+    background: var(--vscode-testing-iconPassed, rgba(40,167,69,0.2));
+    color: var(--vscode-editor-foreground);
+  }
+  .timestamp { color: var(--vscode-descriptionForeground); }
+  .message-body { padding: 12px 16px; background: transparent; }
+  .markdown-body { font-size: 0.95em; line-height: 1.65; }
+  .markdown-body > *:first-child { margin-top: 0; }
+  .markdown-body > *:last-child { margin-bottom: 0; }
+  .markdown-body h1,
+  .markdown-body h2,
+  .markdown-body h3,
+  .markdown-body h4,
+  .markdown-body h5,
+  .markdown-body h6 {
+    margin: 1em 0 0.4em; font-weight: 600; line-height: 1.3;
+  }
+  .markdown-body h1 { font-size: 1.4em; }
+  .markdown-body h2 { font-size: 1.2em; }
+  .markdown-body h3 { font-size: 1.05em; }
+  .markdown-body p { margin: 0.5em 0; }
+  .markdown-body ul, .markdown-body ol { margin: 0.4em 0; padding-left: 1.6em; }
+  .markdown-body li { margin: 0.2em 0; }
+  .markdown-body code {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 0.9em;
+    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .markdown-body pre {
+    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.12));
+    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
+    border-radius: 4px;
+    padding: 10px 14px;
+    overflow-x: auto;
+    margin: 0.6em 0;
+  }
+  .markdown-body pre code { background: transparent; padding: 0; border-radius: 0; font-size: 0.9em; white-space: pre; }
+  .markdown-body blockquote {
+    margin: 0.5em 0;
+    padding: 4px 12px;
+    border-left: 3px solid var(--vscode-textBlockQuote-border, rgba(128,128,128,0.4));
+    background: var(--vscode-textBlockQuote-background, rgba(128,128,128,0.05));
+    color: var(--vscode-descriptionForeground);
+  }
+  .markdown-body table { border-collapse: collapse; margin: 0.6em 0; font-size: 0.9em; width: 100%; }
+  .markdown-body th, .markdown-body td {
+    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3));
+    padding: 5px 10px;
+    text-align: left;
+  }
+  .markdown-body th {
+    background: var(--vscode-sideBarSectionHeader-background, rgba(128,128,128,0.1));
+    font-weight: 600;
+  }
+  .markdown-body a { color: var(--vscode-textLink-foreground); text-decoration: none; }
+  .markdown-body hr { border: none; border-top: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.3)); margin: 1em 0; }
+`;
+
+function generateNonce(): string {
+  let text = "";
+  const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}
+
+export function htmlDocument(extraStyles: string, body: string): string {
+  const nonce = generateNonce();
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}';">
+<style nonce="${nonce}">
+${sharedStyles}
+${extraStyles}
+</style>
+</head>
+<body>
+${body}
+</body>
+</html>`;
+}
+
+export function renderMessageBlock(role: "user" | "assistant", renderedBodyHtml: string, headerExtra = ""): string {
+  const roleClass = role === "user" ? "user-role" : "assistant-role";
+  const roleLabel = role === "user" ? "User" : "Assistant";
+  return `<div class="message ${role}-message">
+    <div class="message-header"><span class="role-label ${roleClass}">${roleLabel}</span>${headerExtra}</div>
+    <div class="message-body markdown-body">${renderedBodyHtml}</div>
+  </div>`;
+}

--- a/src/webview/SessionTreeViewProvider.ts
+++ b/src/webview/SessionTreeViewProvider.ts
@@ -5,7 +5,7 @@ import { getWebviewHtml, getNonce } from "./getWebviewHtml";
 import { renameSession } from "../rename";
 import { ClaudeTerminalService } from "../terminal";
 import { ISessionDiscoveryService } from "../discovery/types";
-import { SessionPromptNode } from "../models";
+import { SessionPromptNode, SessionNode } from "../models";
 import { confirmAndDeleteSessions, confirmDangerousLaunch } from "../utils/sessionActions";
 
 export class SessionTreeViewProvider implements vscode.WebviewViewProvider {
@@ -18,7 +18,8 @@ export class SessionTreeViewProvider implements vscode.WebviewViewProvider {
     private readonly terminalService: ClaudeTerminalService,
     private readonly discovery: ISessionDiscoveryService,
     private readonly outputChannel: vscode.OutputChannel,
-    private readonly onOpenPromptPreview: (node: SessionPromptNode) => void
+    private readonly onOpenPromptPreview: (node: SessionPromptNode) => void,
+    private readonly onViewSession: (session: SessionNode) => void
   ) {}
 
   public resolveWebviewView(
@@ -177,6 +178,14 @@ export class SessionTreeViewProvider implements vscode.WebviewViewProvider {
           timestampIso: prompt.timestampIso
         };
         this.onOpenPromptPreview(node);
+        break;
+      }
+
+      case "viewSession": {
+        const session = this.stateManager.getSessionById(msg.sessionId);
+        if (session) {
+          this.onViewSession(session);
+        }
         break;
       }
 

--- a/src/webview/SessionTreeViewProvider.ts
+++ b/src/webview/SessionTreeViewProvider.ts
@@ -19,7 +19,7 @@ export class SessionTreeViewProvider implements vscode.WebviewViewProvider {
     private readonly discovery: ISessionDiscoveryService,
     private readonly outputChannel: vscode.OutputChannel,
     private readonly onOpenPromptPreview: (node: SessionPromptNode) => void,
-    private readonly onViewSession: (session: SessionNode) => void
+    private readonly onViewSession: (session: SessionNode) => Promise<void>
   ) {}
 
   public resolveWebviewView(
@@ -175,7 +175,8 @@ export class SessionTreeViewProvider implements vscode.WebviewViewProvider {
           promptTitle: prompt.promptTitle,
           promptRaw: prompt.promptRaw,
           responseRaw: prompt.responseRaw,
-          timestampIso: prompt.timestampIso
+          timestampIso: prompt.timestampIso,
+          timestampMs: prompt.timestampMs
         };
         this.onOpenPromptPreview(node);
         break;
@@ -184,7 +185,7 @@ export class SessionTreeViewProvider implements vscode.WebviewViewProvider {
       case "viewSession": {
         const session = this.stateManager.getSessionById(msg.sessionId);
         if (session) {
-          this.onViewSession(session);
+          await this.onViewSession(session);
         }
         break;
       }

--- a/src/webview/messages.ts
+++ b/src/webview/messages.ts
@@ -57,5 +57,6 @@ export type WebviewToExtensionMessage =
   | { type: "toggleWorkspaceExpand"; workspaceUri: string }
   | { type: "toggleSessionExpand"; sessionId: string }
   | { type: "openPromptPreview"; sessionId: string; promptId: string }
+  | { type: "viewSession"; sessionId: string }
   | { type: "clearFilter" }
   | { type: "search"; query: string };

--- a/src/webview/webviewScript.ts
+++ b/src/webview/webviewScript.ts
@@ -168,6 +168,7 @@ export function getWebviewScript(): string {
 
             const hoverActions = isRenaming ? '' :
               '<span class="hover-actions">' +
+              '<button class="action-btn" data-action="viewSession" data-session-id="' + escapeHtml(session.sessionId) + '" title="View Session"><span class="codicon codicon-eye"></span></button>' +
               '<button class="action-btn" data-action="openSession" data-session-id="' + escapeHtml(session.sessionId) + '" title="Open Session"><img src="' + (container.dataset.terminalGreenUri || '') + '" /></button>' +
               '<button class="action-btn" data-action="openSessionDangerously" data-session-id="' + escapeHtml(session.sessionId) + '" title="Open Session (Skip Permissions)"><img src="' + (container.dataset.terminalRedUri || '') + '" /></button>' +
               '<button class="action-btn" data-action="startRename" data-session-id="' + escapeHtml(session.sessionId) + '" title="Rename"><span class="codicon codicon-edit"></span></button>' +
@@ -257,6 +258,10 @@ export function getWebviewScript(): string {
           const action = actionBtn.dataset.action;
           const sessionId = actionBtn.dataset.sessionId;
 
+          if (action === 'viewSession') {
+            vscode.postMessage({ type: 'viewSession', sessionId });
+            return;
+          }
           if (action === 'openSession') {
             vscode.postMessage({ type: 'openSession', sessionId });
             return;

--- a/src/webview/webviewScript.ts
+++ b/src/webview/webviewScript.ts
@@ -168,7 +168,7 @@ export function getWebviewScript(): string {
 
             const hoverActions = isRenaming ? '' :
               '<span class="hover-actions">' +
-              '<button class="action-btn" data-action="viewSession" data-session-id="' + escapeHtml(session.sessionId) + '" title="View Session"><span class="codicon codicon-eye"></span></button>' +
+              '<button class="action-btn" data-action="viewSession" data-session-id="' + escapeHtml(session.sessionId) + '" title="View Session" aria-label="View Session"><span class="codicon codicon-eye"></span></button>' +
               '<button class="action-btn" data-action="openSession" data-session-id="' + escapeHtml(session.sessionId) + '" title="Open Session"><img src="' + (container.dataset.terminalGreenUri || '') + '" /></button>' +
               '<button class="action-btn" data-action="openSessionDangerously" data-session-id="' + escapeHtml(session.sessionId) + '" title="Open Session (Skip Permissions)"><img src="' + (container.dataset.terminalRedUri || '') + '" /></button>' +
               '<button class="action-btn" data-action="startRename" data-session-id="' + escapeHtml(session.sessionId) + '" title="Rename"><span class="codicon codicon-edit"></span></button>' +


### PR DESCRIPTION
## Summary

- Adds an eye icon button on each session entry that opens the full conversation (all prompts + responses) in a read-only WebviewPanel editor tab
- Clicking a prompt's sub-entry view now also renders markdown and shows the assistant response (was plain text, prompt-only before)
- Adds `markdown-it` for server-side markdown rendering (`enableScripts: false` preserved on all panels)
- Extracts shared HTML/CSS into `src/viewHtml.ts` to eliminate ~200 lines of duplication between the two panel builders

🤖 Generated with [Claude Code](https://claude.com/claude-code)